### PR TITLE
Docker container now runs 'yamllint' on entry.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,8 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.license="GPLv3" \
       org.label-schema.build-date=$BUILD_DATE
 
-WORKDIR /yaml
-
 RUN pip install yamllint && \
     rm -rf ~/.cache/pip
 
-CMD ["yamllint", "--version"]
+ENTRYPOINT ["yamllint"]
+CMD ["--version"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Per default, the docker will give you the version number of yamllint.
 If you want to do linting you'll have to run a specific command:
 
 ```
-docker run --rm -v <path for yaml to lint>:/yaml sdesbure/yamllint yamllint youryamlfiles.yaml
+docker run --rm --mount type=bind,source="${PWD}",target=/myapp -w /myapp sdesbure/yamllint ./.circleci/config.yml
 ```
 
 ## In gitlab ci runner


### PR DESCRIPTION
Thanks for creating this repo. I'm using it for checking my Travis YAML file for Sheldon: https://github.com/housni/Sheldon/blob/cleanup/Makefile#L244

My PR does the following:
- REMOVES `WORKDIR` from Dockerfile. It makes more sense to mount it on a Docker run so that we can specify the directory mount dir and the workdir and not have to worry about mapping to `/yaml`.
- ADDS an `ENTRYPOINT` with the `yamllint` executable so that, in a `docker run`, you can just pass the file names into the container and `yamllint` will run against them. Failure to provide file names will result in `yamllint --version` being run (default).
- CHANGES the `README.md` contents to reflect the changes mentioned above.